### PR TITLE
Fix conversion of observation time to UTC

### DIFF
--- a/pyweatherbitdata/helpers.py
+++ b/pyweatherbitdata/helpers.py
@@ -99,7 +99,7 @@ class Conversions:
     def utc_from_datetimestring(self, datestring: str) -> dt.datetime:
         """Return a UTC time from a datetime string."""
         date_obj = dt.datetime.strptime(f"{datestring}", "%Y-%m-%d %H:%M")
-        return date_obj.astimezone(UTC)
+        return date_obj.replace(tzinfo=UTC)
 
     def alert_descriptions(self, alert_text: str):
         """Return alert description in English and Local language."""


### PR DESCRIPTION
Since date_obj doesn't contain a time zone (see below), the astimezone method assumes local time, so it subtracts the local offset when converting to UTC. The fix just updates the tzinfo property to UTC.

```
    def utc_from_datetimestring(self, datestring: str) -> dt.datetime:
        """Return a UTC time from a datetime string."""
        date_obj = dt.datetime.strptime(f"{datestring}", "%Y-%m-%d %H:%M")
        return date_obj.astimezone(UTC)
```